### PR TITLE
story-1800-add-new-api-endpoints-to-php-lib

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -7,13 +7,18 @@ use GuzzleHttp\Psr7\Uri;
 use Rentlio\Api\Request\AbstractRequest;
 use Rentlio\Api\Request\CreateInvoiceItemForReservationRequest;
 use Rentlio\Api\Request\GetMyDataRequest;
+use Rentlio\Api\Request\ListAllArrivalArrangementsRequest;
+use Rentlio\Api\Request\ListAllCheckedInGuestsRequest;
 use Rentlio\Api\Request\ListAllCurrenciesRequest;
+use Rentlio\Api\Request\ListAllDocumentTypesRequest;
 use Rentlio\Api\Request\ListAllPropertiesRequest;
+use Rentlio\Api\Request\ListAllProvidedServiceTypesRequest;
 use Rentlio\Api\Request\ListAllReservationsRequest;
 use Rentlio\Api\Request\ListAllReservationStatusesRequest;
 use Rentlio\Api\Request\ListAllReservationsTodayForUnitRequest;
 use Rentlio\Api\Request\ListAllServicesForPropertyRequest;
 use Rentlio\Api\Request\ListAllServicesPaymentTypesRequest;
+use Rentlio\Api\Request\ListAllTouristTaxCategoriesRequest;
 use Rentlio\Api\Request\ListAllUnitsRequest;
 use Rentlio\Api\Request\ListAllUnitTypesRequest;
 use Rentlio\Api\Request\ListAvailableUnitTypesRequest;
@@ -328,4 +333,66 @@ class Client
     {
         return $this->send($request);
     }
+
+    /**
+     * Calls api endpoint for getting all rentl.io document types enumeration used for a guest
+     *
+     * @return mixed|\Psr\Http\Message\ResponseInterface
+     */
+    public function listAllDocumentTypes()
+    {
+        $request = new ListAllDocumentTypesRequest();
+        return $this->send($request);
+    }
+
+    /**
+     * Calls api endpoint for getting all rentl.io arrival arrangements enumeration used for a guest
+     *
+     * @return mixed|\Psr\Http\Message\ResponseInterface
+     */
+    public function listAllArrivalArrangements()
+    {
+        $request = new ListAllArrivalArrangementsRequest();
+        return $this->send($request);
+    }
+
+    /**
+     * Calls api endpoint for getting all rentl.io tourist tax categories enumeration used for a guest
+     *
+     * @return mixed|\Psr\Http\Message\ResponseInterface
+     */
+    public function listAllTouristTaxCategories()
+    {
+        $request = new ListAllTouristTaxCategoriesRequest();
+        return $this->send($request);
+    }
+
+    /**
+     * Calls api endpoint for getting all rentl.io provided service types enumeration used for a guest
+     *
+     * @return mixed|\Psr\Http\Message\ResponseInterface
+     */
+    public function listAllProvidedServiceTypes()
+    {
+        $request = new ListAllProvidedServiceTypesRequest();
+        return $this->send($request);
+    }
+
+    /**
+     * Calls api endpoint for getting all reservations in date range
+     * for specified propertyId where reservation holders that are checked-in in some date range
+     *
+     * @param $propertyId
+     * @param \DateTime $dateFrom
+     * @param \DateTime $dateTo
+     * @return mixed|\Psr\Http\Message\ResponseInterface
+     */
+    public function listAllCheckedInGuests($propertyId, \DateTime $dateFrom, \DateTime $dateTo)
+    {
+        $request = new ListAllCheckedInGuestsRequest($propertyId);
+        $request->setDateFrom($dateFrom->format('Y-m-d'));
+        $request->setDateTo($dateTo->format('Y-m-d'));
+        return $this->send($request);
+    }
+
 }

--- a/src/Request/ListAllArrivalArrangementsRequest.php
+++ b/src/Request/ListAllArrivalArrangementsRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rentlio\Api\Request;
+
+/**
+ * Class ListAllArrivalArrangementsRequest
+ * @package Rentlio\Api\Request
+ *
+ * GET Request for listing all arrival arrangements supported for a guest used in rentl.io
+ * This is enumeration, that can be used inside other api calls, when needed.
+ */
+class ListAllArrivalArrangementsRequest extends AbstractRequest
+{
+    public function __construct()
+    {
+        parent::__construct("GET", "/enums/guests/arrival-arrangements");
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueryParams()
+    {
+        return [];
+    }
+}

--- a/src/Request/ListAllCheckedInGuestsRequest.php
+++ b/src/Request/ListAllCheckedInGuestsRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Rentlio\Api\Request;
+
+/**
+ * Class ListAllCheckedInGuestsRequest
+ * @package Rentlio\Api\Request
+ * GET Request for listing reservations with reservation holders that are checked-In at property in some date range
+ */
+class ListAllCheckedInGuestsRequest extends AbstractRequest
+{
+
+    /**
+     * @var string ISO 8601 Date format
+     */
+    protected $dateFrom;
+
+    /**
+     * @var string ISO 8601 Date format
+     */
+    protected $dateTo;
+
+    public function __construct($id)
+    {
+        parent::__construct("GET", "/properties/" . $id . "/guests/checked-in");
+    }
+
+    public function setDateFrom($dateFrom)
+    {
+        $this->dateFrom = $dateFrom;
+        return $this;
+    }
+
+    public function setDateTo($dateTo)
+    {
+        $this->dateTo = $dateTo;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueryParams()
+    {
+        return [
+            'from' => $this->dateFrom,
+            'to'   => $this->dateTo,
+        ];
+    }
+}

--- a/src/Request/ListAllDocumentTypesRequest.php
+++ b/src/Request/ListAllDocumentTypesRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rentlio\Api\Request;
+
+/**
+ * Class ListAllDocumentTypesRequest
+ * @package Rentlio\Api\Request
+ *
+ * GET Request for listing all document types an guest can be checked used in rentl.io
+ * This is enumeration, that can be used inside other api calls, when needed.
+ */
+class ListAllDocumentTypesRequest extends AbstractRequest
+{
+    public function __construct()
+    {
+        parent::__construct("GET", "/enums/guests/document-types");
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueryParams()
+    {
+        return [];
+    }
+}

--- a/src/Request/ListAllProvidedServiceTypesRequest.php
+++ b/src/Request/ListAllProvidedServiceTypesRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rentlio\Api\Request;
+
+/**
+ * Class ListAllProvidedServiceTypesRequest
+ * @package Rentlio\Api\Request
+ *
+ * GET Request for listing all provided service types supported for a guest used in rentl.io
+ * This is enumeration, that can be used inside other api calls, when needed.
+ */
+class ListAllProvidedServiceTypesRequest extends AbstractRequest
+{
+    public function __construct()
+    {
+        parent::__construct("GET", "/enums/guests/provided-services-types");
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueryParams()
+    {
+        return [];
+    }
+}

--- a/src/Request/ListAllTouristTaxCategoriesRequest.php
+++ b/src/Request/ListAllTouristTaxCategoriesRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rentlio\Api\Request;
+
+/**
+ * Class ListAllTouristTaxCategoriesRequest
+ * @package Rentlio\Api\Request
+ *
+ * GET Request for listing all tourist tax categories supported for a guest used in rentl.io
+ * This is enumeration, that can be used inside other api calls, when needed.
+ */
+class ListAllTouristTaxCategoriesRequest extends AbstractRequest
+{
+    public function __construct()
+    {
+        parent::__construct("GET", "/enums/guests/tax-categories");
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueryParams()
+    {
+        return [];
+    }
+}

--- a/tests/Request/ListAllArrivalArrangementsRequestTest.php
+++ b/tests/Request/ListAllArrivalArrangementsRequestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+
+class ListAllArrivalArrangementsRequestTest extends PHPUnit_Framework_TestCase
+{
+    public function testRequestDefaultUri()
+    {
+        $request = new \Rentlio\Api\Request\ListAllArrivalArrangementsRequest();
+        $uri     = $request->getUri();
+
+        $this->assertEquals('/enums/guests/arrival-arrangements', $uri->getPath());
+        $this->assertEquals('order_by=id&order_direction=ASC&page=1', $uri->getQuery());
+    }
+
+    public function testRequestSortChangedUri()
+    {
+        $request = new \Rentlio\Api\Request\ListAllArrivalArrangementsRequest();
+        $request
+            ->setSortOrder('DESC')
+            ->setSortBy('name');
+        $uri = $request->getUri();
+
+        $this->assertEquals('/enums/guests/arrival-arrangements', $uri->getPath());
+        $this->assertEquals('order_by=name&order_direction=DESC&page=1', $uri->getQuery());
+    }
+}

--- a/tests/Request/ListAllCheckedInGuestsRequestTest.php
+++ b/tests/Request/ListAllCheckedInGuestsRequestTest.php
@@ -1,0 +1,29 @@
+<?php
+
+class ListAllCheckedInGuestsRequestTest extends PHPUnit_Framework_TestCase
+{
+    public function testRequestDefaultUri()
+    {
+        $request = new \Rentlio\Api\Request\ListAllCheckedInGuestsRequest(1);
+        $uri     = $request->getUri();
+
+        $this->assertEquals('/properties/1/guests/checked-in', $uri->getPath());
+        $this->assertEquals('order_by=id&order_direction=ASC&page=1', $uri->getQuery());
+    }
+
+    public function testRequestSortChangedUri()
+    {
+        $request = new \Rentlio\Api\Request\ListAllCheckedInGuestsRequest(1);
+        $request
+            ->setSortOrder('DESC')
+            ->setSortBy('name')
+            ->setDateTo('2017-12-28')
+            ->setDateFrom('2017-12-25');
+
+        $uri = $request->getUri();
+
+        $this->assertEquals('/properties/1/guests/checked-in', $uri->getPath());
+        $this->assertEquals('order_by=name&order_direction=DESC&page=1' .
+            '&from=2017-12-25&to=2017-12-28', $uri->getQuery());
+    }
+}

--- a/tests/Request/ListAllDocumentTypesRequestTest.php
+++ b/tests/Request/ListAllDocumentTypesRequestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+
+class ListAllDocumentTypesRequestTest extends PHPUnit_Framework_TestCase
+{
+    public function testRequestDefaultUri()
+    {
+        $request = new \Rentlio\Api\Request\ListAllDocumentTypesRequest();
+        $uri     = $request->getUri();
+
+        $this->assertEquals('/enums/guests/document-types', $uri->getPath());
+        $this->assertEquals('order_by=id&order_direction=ASC&page=1', $uri->getQuery());
+    }
+
+    public function testRequestSortChangedUri()
+    {
+        $request = new \Rentlio\Api\Request\ListAllDocumentTypesRequest();
+        $request
+            ->setSortOrder('DESC')
+            ->setSortBy('name');
+        $uri = $request->getUri();
+
+        $this->assertEquals('/enums/guests/document-types', $uri->getPath());
+        $this->assertEquals('order_by=name&order_direction=DESC&page=1', $uri->getQuery());
+    }
+}

--- a/tests/Request/ListAllProvidedServiceTypesRequestTest.php
+++ b/tests/Request/ListAllProvidedServiceTypesRequestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+
+class ListAllProvidedServiceTypesRequestTest extends PHPUnit_Framework_TestCase
+{
+    public function testRequestDefaultUri()
+    {
+        $request = new \Rentlio\Api\Request\ListAllProvidedServiceTypesRequest();
+        $uri     = $request->getUri();
+
+        $this->assertEquals('/enums/guests/provided-services-types', $uri->getPath());
+        $this->assertEquals('order_by=id&order_direction=ASC&page=1', $uri->getQuery());
+    }
+
+    public function testRequestSortChangedUri()
+    {
+        $request = new \Rentlio\Api\Request\ListAllProvidedServiceTypesRequest();
+        $request
+            ->setSortOrder('DESC')
+            ->setSortBy('name');
+        $uri = $request->getUri();
+
+        $this->assertEquals('/enums/guests/provided-services-types', $uri->getPath());
+        $this->assertEquals('order_by=name&order_direction=DESC&page=1', $uri->getQuery());
+    }
+}

--- a/tests/Request/ListAllTouristTaxCategoriesRequestTest.php
+++ b/tests/Request/ListAllTouristTaxCategoriesRequestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+
+class ListAllTouristTaxCategoriesRequestTest extends PHPUnit_Framework_TestCase
+{
+    public function testRequestDefaultUri()
+    {
+        $request = new \Rentlio\Api\Request\ListAllTouristTaxCategoriesRequest();
+        $uri     = $request->getUri();
+
+        $this->assertEquals('/enums/guests/tax-categories', $uri->getPath());
+        $this->assertEquals('order_by=id&order_direction=ASC&page=1', $uri->getQuery());
+    }
+
+    public function testRequestSortChangedUri()
+    {
+        $request = new \Rentlio\Api\Request\ListAllTouristTaxCategoriesRequest();
+        $request
+            ->setSortOrder('DESC')
+            ->setSortBy('name');
+        $uri = $request->getUri();
+
+        $this->assertEquals('/enums/guests/tax-categories', $uri->getPath());
+        $this->assertEquals('order_by=name&order_direction=DESC&page=1', $uri->getQuery());
+    }
+}


### PR DESCRIPTION
# Story 1800 add new api endpoints to php lib

## Problem
Add support for new guest enums and guests checked in some time span endpoint.

## Solution
Implemented 4 enums and 1 endpoint for getting guests checked in in some range.

Unit tests are included in PR